### PR TITLE
Do not use $1 to get the area code

### DIFF
--- a/lib/Number/Phone/BR.pm
+++ b/lib/Number/Phone/BR.pm
@@ -30,9 +30,10 @@ sub BUILDARGS {
     my $number_sane = _sanitize_number($number)
       or return \%args;
 
+    ($areacode) = $number_sane =~ m{ \( ([0-9]+) \) }x;
     $number_sane =~ s{ \( ([0-9]+) \) }{}x;
 
-    if ( $areacode = $1 ) {
+    if ( $areacode ) {
         $areacode =~ s/^0//;
         $subscriber = $number_sane;
     }


### PR DESCRIPTION
If the third party program uses a regex match that is successful while the substitution in N::P::BR is unsuccessful
$1 contains the value of the successful regex match in the third party program. Then code2area might result in an
error.

    $ perl -MNumber::Phone -E "my $nr = Number::Phone->new(\"BR\", \"+55 (011) 2345-6789\"); say $nr->is_valid"
    1
    $ perl -MNumber::Phone -E "my $var = "Phone"; $var =~ m{([A-z0-9]+)}; my $nr = Number::Phone->new(\"BR\", \"+55 (011) 2345-6789\"); say $nr->is_valid"
    Not a valid Brazilian phone number: +5501123456789 at /usr/local/share/perl/5.26.1/Number/Phone/BR.pm line 70.
        Number::Phone::BR::BUILD(Number::Phone::BR=HASH(0x55b696a624c8), HASH(0x55b696c4b278)) called at (eval 10) line 45
        Number::Phone::BR::new("Number::Phone::BR", "+5501123456789") called at /usr/local/share/perl/5.26.1/Number/Phone.pm line 222
        Number::Phone::new("Number::Phone", "BR", "011 2345-6789") called at -e line 1